### PR TITLE
dplyr::row_number()

### DIFF
--- a/R/group_mutate.R
+++ b/R/group_mutate.R
@@ -25,7 +25,7 @@
 #'
 #' group_mutate(datasets::mtcars,
 #'                     c("cyl", "gear"),
-#'                     rank = row_number(),
+#'                     rank = dplyr::row_number(),
 #'                     arrangeTerms = "-disp") %.>%
 #'   head(.)
 #'

--- a/man/group_mutate.Rd
+++ b/man/group_mutate.Rd
@@ -38,7 +38,7 @@ group_mutate(datasets::mtcars,
 
 group_mutate(datasets::mtcars,
                     c("cyl", "gear"),
-                    rank = row_number(),
+                    rank = dplyr::row_number(),
                     arrangeTerms = "-disp") \%.>\%
   head(.)
 


### PR DESCRIPTION
Starting from `dplyr` 1.0.0, `row_number()` won't be magic, so packages have to specify where it's from. 